### PR TITLE
Register ejs as .ejs handler to avoid error when monitor path requested

### DIFF
--- a/lib/monitor.js
+++ b/lib/monitor.js
@@ -30,6 +30,8 @@ var Monitor = module.exports = function Monitor(options) {
 
     var app = express.createServer();
 
+    app.register('.ejs', ejs);
+
     var self = this;
     app.set('views', __dirname + '/../public/views');
     app.use(express.static(__dirname + '/../public'));

--- a/public/views/logs.ejs
+++ b/public/views/logs.ejs
@@ -6,7 +6,7 @@
             <td>File</td>
             <td>Size</td>
             <td>Created</td>
-            <td>Last Modifled</td>
+            <td>Last Modified</td>
         </tr>
     </thead>
     <tbody>


### PR DESCRIPTION
When cluster2 is used as a dependency by another project, accessing the monitor path elicits this error stack:

```
Error: Cannot find module 'ejs'
    at Function._resolveFilename (module.js:337:11)
    at Function._load (module.js:279:25)
    at Module.require (module.js:359:17)
    at require (module.js:375:17)
    at View.templateEngine (/[...]/node_modules/express/lib/view/view.js:134:38)
    at Function.compile (/[...]/node_modules/express/lib/view.js:68:17)
    at ServerResponse._render (/[...]/node_modules/express/lib/view.js:417:18)
    at ServerResponse.render (/[...]/node_modules/express/lib/view.js:318:17)
    at /[...]/node_modules/cluster2/lib/monitor.js:45:17
    at callbacks (/[...]/node_modules/cluster2/node_modules/express/lib/router/index.js:272:11)
```

Effectively, without the `app.register` call, node is using the current project's node_modules as it's starting point for evaluating the require path, and not the dependency's nested node_modules. I don't know why, but it's probably due to closures at some point in the stack that are preserving the modified "current working directory".
