### PR TITLE
Remove pid from master pidfile name. Closes #20.

### DIFF
--- a/lib/process.js
+++ b/lib/process.js
@@ -189,7 +189,7 @@ Process.prototype.listen = function() {
             misc.ensureDir(process.cwd() + '/pids', true); // Ensure pids dir
             misc.ensureDir(process.cwd() + '/logs'); // Ensure logs dir
 
-            fs.writeFileSync(self.options.pids + '/master.' + self.stats.pid + '.pid', self.stats.pid);
+            fs.writeFileSync(self.options.pids + '/master.pid', self.stats.pid);
             console.log('Master ' + process.pid + ' started');
 
             // Fork workers


### PR DESCRIPTION
There's no use of a .pid file storing the PID if you need to know
the PID in order to read the file...
