### PR TITLE
Allow user to specify location of pids and logs

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -36,6 +36,8 @@ exports.defaultOptions = {
     cluster: true,
     port: 3000,
     monPort: 3001,
+    pids: process.cwd() + '/pids',
+    logs: process.cwd() + '/logs',
     ecv: {
         path: '/ecv'
     },
@@ -65,8 +67,8 @@ Cluster.prototype.listen = function(createApp, cb) {
 
     if(self.options.cluster) {
         var master = new Process({
-            pids: process.cwd() + '/pids',
-            logs: process.cwd() + '/logs',
+            pids: self.options.pids,
+            logs: self.options.logs,
             port: self.options.port,
             host: self.options.host || '0.0.0.0',
             monPort: self.options.monPort,


### PR DESCRIPTION
Readme stated user could specify location of pids, but the code didn't permit that.  Also adjusted the code so the log location could be specified as well.
